### PR TITLE
Feat!: add maven2_upload format for Nexus2.x uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,27 +25,28 @@ Publishes content to Sonatype Nexus Repository servers.
 
 <!-- markdownlint-enable MD013 -->
 
-| Format      | Description             | Example Files                |
-| ----------- | ----------------------- | ---------------------------- |
-| `raw`       | Generic binary files    | `*.zip`, `*.tar.gz`, `*.bin` |
-| `maven2`    | Java artifacts          | `*.jar`, `*.war`, `*.pom`    |
-| `npm`       | Node.js packages        | `*.tgz`                      |
-| `docker`    | Container images        | N/A (registry API)           |
-| `helm`      | Kubernetes charts       | `*.tgz`                      |
-| `pypi`      | Python packages         | `*.whl`, `*.tar.gz`          |
-| `nuget`     | .NET packages           | `*.nupkg`                    |
-| `rubygems`  | Ruby gems               | `*.gem`                      |
-| `apt`       | Debian packages         | `*.deb`                      |
-| `yum`/`rpm` | Red Hat packages        | `*.rpm`                      |
-| `composer`  | PHP packages            | `*.zip`                      |
-| `conan`     | C/C++ packages          | `*.tgz`                      |
-| `conda`     | Multi-language packages | `*.tar.bz2`                  |
-| `r`         | R packages              | `*.tar.gz`                   |
-| `go`        | Go modules              | `*.zip`                      |
-| `p2`        | Eclipse plugins         | `*.jar`                      |
-| `gitlfs`    | Git LFS objects         | Any large files              |
-| `cocoapods` | iOS/macOS packages      | `*.tar.gz`                   |
-| `bower`     | Frontend packages       | `*.tar.gz`                   |
+| Format          | Description             | Example Files                |
+| --------------- | ----------------------- | ---------------------------- |
+| `raw`           | Generic binary files    | `*.zip`, `*.tar.gz`, `*.bin` |
+| `maven2`        | Java artifacts          | `*.jar`, `*.war`, `*.pom`    |
+| `maven2_upload` | Maven m2repo trees      | Pre-built `m2repo/` dirs     |
+| `npm`           | Node.js packages        | `*.tgz`                      |
+| `docker`        | Container images        | N/A (registry API)           |
+| `helm`          | Kubernetes charts       | `*.tgz`                      |
+| `pypi`          | Python packages         | `*.whl`, `*.tar.gz`          |
+| `nuget`         | .NET packages           | `*.nupkg`                    |
+| `rubygems`      | Ruby gems               | `*.gem`                      |
+| `apt`           | Debian packages         | `*.deb`                      |
+| `yum`/`rpm`     | Red Hat packages        | `*.rpm`                      |
+| `composer`      | PHP packages            | `*.zip`                      |
+| `conan`         | C/C++ packages          | `*.tgz`                      |
+| `conda`         | Multi-language packages | `*.tar.bz2`                  |
+| `r`             | R packages              | `*.tar.gz`                   |
+| `go`            | Go modules              | `*.zip`                      |
+| `p2`            | Eclipse plugins         | `*.jar`                      |
+| `gitlfs`        | Git LFS objects         | Any large files              |
+| `cocoapods`     | iOS/macOS packages      | `*.tar.gz`                   |
+| `bower`         | Frontend packages       | `*.tar.gz`                   |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -93,6 +94,21 @@ Publishes content to Sonatype Nexus Repository servers.
     repository_name: "helm-charts"
     files_path: "./charts"
     file_pattern: "*.tgz"
+```
+
+### Maven m2repo Upload (Nexus 2.x)
+
+```yaml
+- name: Upload Maven m2repo to Nexus 2.x
+  uses: ./.github/actions/nexus-publish-action
+  with:
+    nexus_server: "https://nexus.example.com"
+    nexus_username: ${{ secrets.NEXUS_USERNAME }}
+    nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+    repository_format: "maven2_upload"
+    repository_name: "maven-snapshots"
+    files_path: "${{ github.workspace }}/m2repo"
+    permit_fail: "false"
 ```
 
 ## Inputs
@@ -148,6 +164,14 @@ Publishes content to Sonatype Nexus Repository servers.
 - **Optional coordinates**: `classifier=sources`, `packaging=jar`
 - **Upload path**: Automatically generated from coordinates
 - **Checksums**: MD5, SHA1, SHA256 uploaded automatically
+
+### Maven2 Upload (Nexus 2.x)
+
+- **Use case**: Upload pre-built `m2repo/` directory trees to Nexus 2.x servers
+- **No coordinates needed**: The upload retains the full directory structure
+- **API endpoint**: Uses `/content/repositories/<repo>/` (Nexus 2.x)
+- **Checksums**: Not double-uploaded (m2repo already contains `.md5`/`.sha1` files)
+- **Note**: `files_path` must be a directory, not a single file
 
 ### npm
 

--- a/action.yaml
+++ b/action.yaml
@@ -121,8 +121,8 @@ runs:
 
         # Validate repository format
         format="${{ inputs.repository_format }}"
-        valid_formats=("raw" "maven2" "npm" "docker" "helm" \
-          "pypi" "nuget" "rubygems" "apt" "yum" "rpm" "composer" \
+        valid_formats=("raw" "maven2" "maven2_upload" "npm" "docker" \
+          "helm" "pypi" "nuget" "rubygems" "apt" "yum" "rpm" "composer" \
           "conan" "conda" "r" "go" "p2" "gitlfs" "cocoapods" "bower")
 
         format_valid=false
@@ -244,6 +244,18 @@ runs:
           local upload_path="$4"
 
           case "$format" in
+            "maven2_upload")
+              # Maven upload format for pre-built m2repo directory trees.
+              # Preserves the relative path from files_path as the URL path.
+              # Uses Nexus 2.x content API: /content/repositories/<repo>/
+              # The relative path is passed via upload_path by the caller.
+              if [ -z "$upload_path" ]; then
+                echo "Error: maven2_upload requires upload_path" >&2
+                return 1
+              fi
+              local base="${nexus_url}/content/repositories"
+              echo "${base}/${repo_name}/${upload_path}"
+              ;;
             "maven2")
               # Maven format: /groupId/artifactId/version/filename
               # Parse coordinates
@@ -398,7 +410,7 @@ runs:
             # All credential operations happen here, isolated from
             # logging
             case "$format" in
-              "maven2")
+              "maven2"|"maven2_upload")
                 secure_upload_file "$file" "$upload_url" \
                   "application/octet-stream"
                 ;;
@@ -431,9 +443,22 @@ runs:
             echo "  SHA256: $sha256sum"
           fi
 
+          # For maven2_upload, compute relative path from files_path root
+          # Use local variable to avoid mutating global upload_path
+          local effective_upload_path="$upload_path"
+          if [ "$repo_format" = "maven2_upload" ]; then
+            local files_root="${files_path%/}"
+            local rel_path="${file#${files_root}/}"
+            if [ "$rel_path" = "$file" ]; then
+              echo "❌ File $file is not under files_path $files_root"
+              return 1
+            fi
+            effective_upload_path="$rel_path"
+          fi
+
           # Get upload URL
           upload_url=$(get_upload_url "$repo_format" \
-            "$filename" "$coordinates" "$upload_path")
+            "$filename" "$coordinates" "$effective_upload_path")
           if [ $? -ne 0 ]; then
             echo "❌ Failed to determine upload URL for $filename"
             return 1
@@ -548,6 +573,11 @@ runs:
         declare -a target_files=()
 
         if [ -f "$files_path" ]; then
+          if [ "$repo_format" = "maven2_upload" ]; then
+            echo 'Error: maven2_upload requires files_path to be' \
+              'a directory, not a single file ❌'
+            exit 1
+          fi
           target_files=("$files_path")
         elif [ -d "$files_path" ]; then
           if [ "$file_pattern" = "*" ]; then


### PR DESCRIPTION
## Summary

Add `maven2_upload` repository format that preserves Maven directory structure when uploading pre-built m2repo trees to Nexus 2.x servers.

## Problem

ODL maven-merge jobs deploy artifacts to a local `m2repo/` directory, then the `nexus-publish-action` uploads them to Nexus. Currently:

- The `raw` format uses `basename`, losing the Maven directory structure (`groupId/artifactId/version/`)
- All formats use `/repository/<repo>/` (Nexus 3 API), but ODL runs Nexus 2.14 which uses `/content/repositories/<repo>/`

This causes all uploads to fail with HTTP 400 (see [infrautils run 24076922811](https://github.com/opendaylight/infrautils/actions/runs/24076922811)).

## Solution

Add a new `maven2_upload` format that:

1. **Preserves full relative path** from `files_path` — e.g. `org/opendaylight/infrautils/itestutils/7.1.13-SNAPSHOT/itestutils-7.1.13-20260407.103328-1.pom`
2. **Uses Nexus 2.x content API** — `/content/repositories/<repo>/<path>` instead of `/repository/<repo>/`
3. **Reuses `maven2` secure upload** with `application/octet-stream` content type
4. **Skips double-checksum uploads** — m2repo trees already contain `.md5`/`.sha1` files

### Example

```yaml
- uses: lfreleng-actions/nexus-publish-action@main
  with:
    nexus_server: https://nexus.opendaylight.org
    repository_name: opendaylight.snapshot
    repository_format: maven2_upload
    files_path: "${{ github.workspace }}/m2repo"
```

Produces correct URLs like:
```
https://nexus.opendaylight.org/content/repositories/opendaylight.snapshot/org/opendaylight/infrautils/itestutils/7.1.13-SNAPSHOT/itestutils-7.1.13-20260407.103328-1.pom
```

## Backward Compatibility

- No changes to existing `raw`, `maven2`, or other format behavior
- New format is opt-in via `repository_format: maven2_upload`

## Related

- PR #88 — `permit_fail` default change (complementary, no overlap)
- Issue #89 — fail-fast behavior (separate enhancement)