### PR TITLE
Fix(auth): Default username to GitHub repo name

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -210,9 +210,10 @@ runs:
 
           { set -x; } 2>/dev/null  # See SECURITY NOTES: #1
 
-          # Default username to repository name if not provided
+          # Default username to the GitHub repository name if not provided
+          # (matches the documented default in README.md)
           if [ -z "$nexus_user" ]; then
-            nexus_user="$repo_name"
+            nexus_user="${GITHUB_REPOSITORY##*/}"
           fi
 
           { set +x; } 2>/dev/null  # See SECURITY NOTES: pattern #1


### PR DESCRIPTION
## Summary

The `README.md` documents that `nexus_username` defaults to the **GitHub repository name** when the input is not supplied:

| Name             | Description                       | Default          |
| ---------------- | --------------------------------- | ---------------- |
| `nexus_username` | Nexus username for authentication | GitHub Repo Name |

However, the implementation in `action.yaml` was defaulting to the `repository_name` **input** (i.e. the Nexus repository name), not the GitHub repo name. For example, in a workflow publishing to a Nexus repo called `helm.snapshot` without an explicit `nexus_username`, the action would try to authenticate as the user `helm.snapshot`, rather than the GitHub repository name.

This caused the `Publish Helm Charts [O-RAN-SC Nexus 3]` job on `main` to fail with HTTP 401 on `nexus3.o-ran-sc.org` — see run [#226](https://github.com/lfreleng-actions/nexus-publish-action/actions/runs/24672516797).

## Fix

Derive the default from the always-present `GITHUB_REPOSITORY` environment variable (`owner/name` → `name`) so the runtime behaviour matches the documented default, across all event types.

```yaml
# Default username to the GitHub repository name if not provided
# (matches the documented default in README.md)
if [ -z "$nexus_user" ]; then
  nexus_user="${GITHUB_REPOSITORY##*/}"
fi
```

## Verification

Manually verified credentials against `nexus3.o-ran-sc.org`:

- Username `nexus-publish-action` (i.e. the GitHub repo name) authenticates correctly and can PUT to `helm.snapshot` (HTTP 200).
- Username `helm.snapshot` (the previous default) fails with HTTP 401.

With this fix, the test workflow does NOT need to pass an explicit `nexus_username` — the default produces the correct value (`nexus-publish-action`).

## Notes

- No workflow changes required.
- No README changes required (README already documents the correct intended behaviour).
- Atomic commit, signed, DCO sign-off present.