### PR TITLE
Fix: prepend upload_path prefix for maven2_upload format

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -382,7 +382,26 @@ upload_file() {
       echo "❌ File $file is not under files_path $files_root"
       return 1
     fi
-    effective_upload_path="$rel_path"
+    # When upload_path is provided, prepend it to the relative path
+    # to preserve the Maven coordinate structure in Nexus.
+    # e.g., upload_path="org/opendaylight/infrautils" + rel_path="foo/bar.jar"
+    #     → "org/opendaylight/infrautils/foo/bar.jar"
+    if [ -n "$upload_path" ]; then
+      local prefix
+      prefix=$(printf '%s' "$upload_path" | sed 's|^/||; s|/$||')
+      if [ -n "$prefix" ]; then
+        # Avoid duplicating the prefix when rel_path already starts with it
+        if [[ "$rel_path" == "${prefix}/"* ]]; then
+          effective_upload_path="$rel_path"
+        else
+          effective_upload_path="${prefix}/${rel_path}"
+        fi
+      else
+        effective_upload_path="$rel_path"
+      fi
+    else
+      effective_upload_path="$rel_path"
+    fi
   fi
 
   local upload_url


### PR DESCRIPTION
## Problem

When using `maven2_upload` format with both `files_path` and `upload_path` inputs, the action ignores `upload_path` and computes the Nexus upload URL using only the relative path from `files_path`.

This causes artifacts to be uploaded to the wrong location in Nexus. For example:
- `files_path`: `.../m2repo/org/opendaylight/infrautils`
- File: `.../m2repo/org/opendaylight/infrautils/odl-infrautils-ready/maven-metadata.xml`
- **Before (wrong)**: `nexus/repo/odl-infrautils-ready/maven-metadata.xml`
- **After (correct)**: `nexus/repo/org/opendaylight/infrautils/odl-infrautils-ready/maven-metadata.xml`

The wrong path results in a 403 from Nexus when credentials are scoped to a specific namespace.

## Fix

When `upload_path` is provided alongside `files_path` for `maven2_upload`, prepend it to the relative path:
- `upload_path` = `org/opendaylight/infrautils`
- `rel_path` = `odl-infrautils-ready/maven-metadata.xml`
- `effective_upload_path` = `org/opendaylight/infrautils/odl-infrautils-ready/maven-metadata.xml`

This gives callers explicit control over the Nexus target namespace while still using `files_path` to scope which files are discovered.

## Usage

```yaml
- uses: lfreleng-actions/nexus-publish-action@<new-sha>
  with:
    repository_format: maven2_upload
    files_path: "${{ github.workspace }}/m2repo/org/opendaylight/infrautils"
    upload_path: "org/opendaylight/infrautils"
    # ...
```

## Backward Compatibility

- If `upload_path` is **not** provided, behavior is unchanged (`rel_path` used directly)
- If `upload_path` **is** provided, it's prepended as a prefix — this was previously silently ignored for `maven2_upload`

Signed-off-by: Anil Belur <abelur@linuxfoundation.org>