### PR TITLE
Fix: resolve Zizmor template-injection findings

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -85,6 +85,12 @@ runs:
     - name: 'Validate inputs'
       id: validate
       shell: bash
+      env:
+        INPUT_NEXUS_SERVER: "${{ inputs.nexus_server }}"
+        INPUT_NEXUS_PASSWORD: "${{ inputs.nexus_password }}"
+        INPUT_REPOSITORY_NAME: "${{ inputs.repository_name }}"
+        INPUT_FILES_PATH: "${{ inputs.files_path }}"
+        INPUT_REPOSITORY_FORMAT: "${{ inputs.repository_format }}"
       run: |
         # Validate inputs
         echo 'Validating inputs...'
@@ -97,25 +103,25 @@ runs:
         for input in "${required_inputs[@]}"; do
           case "$input" in
             "nexus_server")
-              if [ -z "${{ inputs.nexus_server }}" ]; then
+              if [ -z "$INPUT_NEXUS_SERVER" ]; then
                 echo 'Error: nexus_server is required ❌'
                 exit 1
               fi
               ;;
             "nexus_password")
-              if [ -z "${{ inputs.nexus_password }}" ]; then
+              if [ -z "$INPUT_NEXUS_PASSWORD" ]; then
                 echo 'Error: nexus_password is required ❌'
                 exit 1
               fi
               ;;
             "repository_name")
-              if [ -z "${{ inputs.repository_name }}" ]; then
+              if [ -z "$INPUT_REPOSITORY_NAME" ]; then
                 echo 'Error: repository_name is required ❌'
                 exit 1
               fi
               ;;
             "files_path")
-              if [ -z "${{ inputs.files_path }}" ]; then
+              if [ -z "$INPUT_FILES_PATH" ]; then
                 echo 'Error: files_path is required ❌'
                 exit 1
               fi
@@ -124,7 +130,7 @@ runs:
         done
 
         # Validate repository format
-        format="${{ inputs.repository_format }}"
+        format="$INPUT_REPOSITORY_FORMAT"
         valid_formats=("raw" "maven2" "maven2_upload" "npm" "docker" \
           "helm" "pypi" "nuget" "rubygems" "apt" "yum" "rpm" "composer" \
           "conan" "conda" "r" "go" "p2" "gitlfs" "cocoapods" "bower")


### PR DESCRIPTION
## Summary

Resolves all 5 medium+ findings reported by the org-wide Zizmor audit
for this repository (5 `template-injection`).

## Changes

Route the five inputs consumed by the `Validate inputs` step
(`nexus_server`, `nexus_password`, `repository_name`, `files_path`,
`repository_format`) through the step `env:` block as `INPUT_*`
variables, referenced as quoted shell variables, so nothing is
interpolated directly into the `run:` body. This matches the convention
the `Publish artifacts to Nexus` step already uses.

As a side benefit, `nexus_password` is no longer rendered into the
step's `run:` script text; it now stays in the step environment only.

Behaviour is preserved. Verified with `zizmor --persona regular
--min-severity medium` reporting 0 findings.