### PR TITLE
CI(security): Resolve zizmor auditor findings

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -20,8 +20,7 @@ jobs:
   update_release_draft:
     name: 'Update Release Draft'
     permissions:
-      # write permission is required to create releases
-      contents: write
+      contents: write  # Required to create and update draft releases
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:

--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -13,6 +13,11 @@ on:
 
 permissions: {}
 
+# Serialize release promotions: only one tag-push run proceeds at a time
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   validate_tag:
     name: 'Validate Tag'
@@ -53,7 +58,7 @@ jobs:
     needs: validate_tag
     runs-on: 'ubuntu-latest'
     permissions:
-      contents: write
+      contents: write  # Promote (publish) the draft release
     timeout-minutes: 5
     steps:
       # Harden the runner used by this workflow

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -47,6 +47,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Setup Helm'
         # yamllint disable-line rule:line-length
@@ -74,6 +76,10 @@ jobs:
     runs-on: 'ubuntu-latest'
     needs:
       - build
+    # Run this job in a dedicated environment so its execution and any
+    # environment-scoped secrets can be gated by environment protection
+    # rules (satisfies zizmor's secrets-outside-env).
+    environment: 'development'
     permissions:
       contents: read
     timeout-minutes: 3
@@ -86,6 +92,8 @@ jobs:
       # Required when tested action is local to this repository
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Download Helm Charts'
         # yamllint disable-line rule:line-length
@@ -158,6 +166,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Download test fixtures'
         # yamllint disable-line rule:line-length
@@ -183,24 +193,28 @@ jobs:
       - name: 'Assert: step failed'
         shell: bash
         run: |
-          echo "Outcome: ${{ steps.bad-creds.outcome }}"
-          if [ "${{ steps.bad-creds.outcome }}" != "failure" ]; then
+          echo "Outcome: ${OUTCOME}"
+          if [ "${OUTCOME}" != "failure" ]; then
             echo "::error::Expected failure but got: \
-              ${{ steps.bad-creds.outcome }}"
+              ${OUTCOME}"
             exit 1
           fi
           echo "✅ Action failed as expected (bad credentials)"
+        env:
+          OUTCOME: ${{ steps.bad-creds.outcome }}
 
       - name: 'Assert: failed_count output is set'
         shell: bash
         run: |
-          count="${{ steps.bad-creds.outputs.failed_count }}"
+          count="${FAILED_COUNT}"
           echo "failed_count=$count"
           if [ -z "$count" ] || [ "$count" -eq 0 ]; then
             echo "::error::Expected non-zero failed_count"
             exit 1
           fi
           echo "✅ failed_count=$count"
+        env:
+          FAILED_COUNT: ${{ steps.bad-creds.outputs.failed_count }}
 
   # Test: HTTP 404 — non-existent repository
   error-bad-repository:
@@ -209,6 +223,10 @@ jobs:
     runs-on: 'ubuntu-latest'
     needs:
       - error-setup
+    # Run this job in a dedicated environment so its execution and any
+    # environment-scoped secrets can be gated by environment protection
+    # rules (satisfies zizmor's secrets-outside-env).
+    environment: 'development'
     permissions:
       contents: read
     timeout-minutes: 3
@@ -220,6 +238,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Download test fixtures'
         # yamllint disable-line rule:line-length
@@ -244,24 +264,28 @@ jobs:
       - name: 'Assert: step failed'
         shell: bash
         run: |
-          echo "Outcome: ${{ steps.bad-repo.outcome }}"
-          if [ "${{ steps.bad-repo.outcome }}" != "failure" ]; then
+          echo "Outcome: ${OUTCOME}"
+          if [ "${OUTCOME}" != "failure" ]; then
             echo "::error::Expected failure but got: \
-              ${{ steps.bad-repo.outcome }}"
+              ${OUTCOME}"
             exit 1
           fi
           echo "✅ Action failed as expected (bad repository)"
+        env:
+          OUTCOME: ${{ steps.bad-repo.outcome }}
 
       - name: 'Assert: failed_count output is set'
         shell: bash
         run: |
-          count="${{ steps.bad-repo.outputs.failed_count }}"
+          count="${FAILED_COUNT}"
           echo "failed_count=$count"
           if [ -z "$count" ] || [ "$count" -eq 0 ]; then
             echo "::error::Expected non-zero failed_count"
             exit 1
           fi
           echo "✅ failed_count=$count"
+        env:
+          FAILED_COUNT: ${{ steps.bad-repo.outputs.failed_count }}
 
   # Test: DNS resolution failure — bogus hostname
   error-dns-failure:
@@ -280,6 +304,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Download test fixtures'
         # yamllint disable-line rule:line-length
@@ -304,24 +330,28 @@ jobs:
       - name: 'Assert: step failed'
         shell: bash
         run: |
-          echo "Outcome: ${{ steps.dns-fail.outcome }}"
-          if [ "${{ steps.dns-fail.outcome }}" != "failure" ]; then
+          echo "Outcome: ${OUTCOME}"
+          if [ "${OUTCOME}" != "failure" ]; then
             echo "::error::Expected failure but got: \
-              ${{ steps.dns-fail.outcome }}"
+              ${OUTCOME}"
             exit 1
           fi
           echo "✅ Action failed as expected (DNS failure)"
+        env:
+          OUTCOME: ${{ steps.dns-fail.outcome }}
 
       - name: 'Assert: failed_count output is set'
         shell: bash
         run: |
-          count="${{ steps.dns-fail.outputs.failed_count }}"
+          count="${FAILED_COUNT}"
           echo "failed_count=$count"
           if [ -z "$count" ] || [ "$count" -eq 0 ]; then
             echo "::error::Expected non-zero failed_count"
             exit 1
           fi
           echo "✅ failed_count=$count"
+        env:
+          FAILED_COUNT: ${{ steps.dns-fail.outputs.failed_count }}
 
   # Test: fail-fast=true (default) stops after first failure
   error-fail-fast-enabled:
@@ -341,6 +371,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Download test fixtures'
         # yamllint disable-line rule:line-length
@@ -367,27 +399,32 @@ jobs:
       - name: 'Assert: step failed'
         shell: bash
         run: |
-          echo "Outcome: ${{ steps.ff-enabled.outcome }}"
-          if [ "${{ steps.ff-enabled.outcome }}" != "failure" ]; then
+          echo "Outcome: ${OUTCOME}"
+          if [ "${OUTCOME}" != "failure" ]; then
             echo "::error::Expected failure but got: \
-              ${{ steps.ff-enabled.outcome }}"
+              ${OUTCOME}"
             exit 1
           fi
           echo "✅ Action failed as expected"
+        env:
+          OUTCOME: ${{ steps.ff-enabled.outcome }}
 
       - name: 'Assert: stopped after first failure'
         shell: bash
         run: |
           # With 3 files and fail_fast=true, only 1 should fail
           # (the rest are skipped)
-          failed="${{ steps.ff-enabled.outputs.failed_count }}"
-          pub="${{ steps.ff-enabled.outputs.publication_count }}"
+          failed="${FAILED_COUNT}"
+          pub="${PUBLICATION_COUNT}"
           echo "failed_count=$failed publication_count=$pub"
           if [ "$failed" != "1" ]; then
             echo "::error::Expected failed_count=1 but got: $failed"
             exit 1
           fi
           echo "✅ fail-fast stopped after first failure"
+        env:
+          FAILED_COUNT: ${{ steps.ff-enabled.outputs.failed_count }}
+          PUBLICATION_COUNT: ${{ steps.ff-enabled.outputs.publication_count }}
 
   # Test: fail-fast=false attempts all files before exiting
   error-fail-fast-disabled:
@@ -407,6 +444,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Download test fixtures'
         # yamllint disable-line rule:line-length
@@ -433,25 +472,29 @@ jobs:
       - name: 'Assert: step failed'
         shell: bash
         run: |
-          echo "Outcome: ${{ steps.ff-disabled.outcome }}"
-          if [ "${{ steps.ff-disabled.outcome }}" != "failure" ]; then
+          echo "Outcome: ${OUTCOME}"
+          if [ "${OUTCOME}" != "failure" ]; then
             echo "::error::Expected failure but got: \
-              ${{ steps.ff-disabled.outcome }}"
+              ${OUTCOME}"
             exit 1
           fi
           echo "✅ Action failed as expected"
+        env:
+          OUTCOME: ${{ steps.ff-disabled.outcome }}
 
       - name: 'Assert: all files attempted'
         shell: bash
         run: |
           # With 3 files and fail_fast=false, all 3 should be tried
-          failed="${{ steps.ff-disabled.outputs.failed_count }}"
+          failed="${FAILED_COUNT}"
           echo "failed_count=$failed"
           if [ "$failed" != "3" ]; then
             echo "::error::Expected failed_count=3 but got: $failed"
             exit 1
           fi
           echo "✅ All files attempted before exit (fail_fast=false)"
+        env:
+          FAILED_COUNT: ${{ steps.ff-disabled.outputs.failed_count }}
 
   # Test: permit_fail=true suppresses exit code on failures
   error-permit-fail:
@@ -471,6 +514,8 @@ jobs:
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Download test fixtures'
         # yamllint disable-line rule:line-length
@@ -495,21 +540,25 @@ jobs:
       - name: 'Assert: step succeeded (permit_fail=true)'
         shell: bash
         run: |
-          echo "Outcome: ${{ steps.permit.outcome }}"
-          if [ "${{ steps.permit.outcome }}" != "success" ]; then
+          echo "Outcome: ${OUTCOME}"
+          if [ "${OUTCOME}" != "success" ]; then
             echo "::error::Expected success but got: \
-              ${{ steps.permit.outcome }}"
+              ${OUTCOME}"
             exit 1
           fi
           echo "✅ Action exited 0 despite failures (permit_fail=true)"
+        env:
+          OUTCOME: ${{ steps.permit.outcome }}
 
       - name: 'Assert: failures were still recorded'
         shell: bash
         run: |
-          failed="${{ steps.permit.outputs.failed_count }}"
+          failed="${FAILED_COUNT}"
           echo "failed_count=$failed"
           if [ -z "$failed" ] || [ "$failed" -eq 0 ]; then
             echo "::error::Expected non-zero failed_count"
             exit 1
           fi
           echo "✅ Failures recorded despite permit_fail=true"
+        env:
+          FAILED_COUNT: ${{ steps.permit.outputs.failed_count }}


### PR DESCRIPTION
## Summary

Drives the [zizmor](https://docs.zizmor.sh) static analysis to **zero
findings at the `auditor` persona** — the level the central CI security
scan uses (previously this branch only cleared `pedantic`, leaving the
`auditor`-only medium findings visible on the dashboard).

## Findings addressed

| Audit | Sev | Count | Fix |
| ----- | --- | ----- | --- |
| `secrets-outside-env` | medium | 2 | Bind the Nexus publish test jobs to the shared `development` environment so secrets are scoped to a gated environment rather than the repository scope. |
| `artipacked` | low | 8 | `persist-credentials: false` on every `actions/checkout`. |
| `template-injection` | low | ~24 | Hoist step `outcome`/`outputs.*` expansions into `env:` vars referenced from `run` blocks. |
| `concurrency-limits` | low | 1 | Workflow-level `concurrency` group on the tag-push release workflow. |
| `undocumented-permissions` | low | 2 | Trailing explanatory comments on non-baseline permission grants. |

## Validation

- `zizmor --persona=auditor .` → **No findings to report**.
- `pre-commit` (yamllint with line-length enforced as error, actionlint, reuse, validators) passes.